### PR TITLE
Fix default NIX_PATH paths

### DIFF
--- a/src/libexpr/eval.cc
+++ b/src/libexpr/eval.cc
@@ -2106,8 +2106,8 @@ Strings EvalSettings::getDefaultNixPath()
     Strings res;
     auto add = [&](const Path & p) { if (pathExists(p)) { res.push_back(p); } };
     add(getHome() + "/.nix-defexpr/channels");
-    add("nixpkgs=" + settings.nixStateDir + "/nix/profiles/per-user/root/channels/nixpkgs");
-    add(settings.nixStateDir + "/nix/profiles/per-user/root/channels");
+    add("nixpkgs=" + settings.nixStateDir + "/profiles/per-user/root/channels/nixpkgs");
+    add(settings.nixStateDir + "/profiles/per-user/root/channels");
     return res;
 }
 


### PR DESCRIPTION
The default entries for nixpkgs and root/channels were not being picked
up due to an extra /nix/ in the middle.